### PR TITLE
No longer request permission in Android

### DIFF
--- a/src/Plugin.Geofence.Android/GeofenceImplementation.cs
+++ b/src/Plugin.Geofence.Android/GeofenceImplementation.cs
@@ -123,7 +123,8 @@ namespace Plugin.Geofence
         {
             if (!CheckPermissions())
             {
-                RequestPermissions();
+                System.Diagnostics.Debug.WriteLine("Permission was not granted, no-oping.");
+                return;
             }
             //Check if location services are enabled
             IsLocationEnabled((bool locationIsEnabled) => {
@@ -699,12 +700,6 @@ namespace Plugin.Geofence
             }
             else
                 return true;
-        }
-
-        private void RequestPermissions()
-        {            
-            ActivityCompat.RequestPermissions((Activity) Application.Context, new[] { Manifest.Permission.AccessFineLocation }, REQUEST_PERMISSIONS_REQUEST_CODE);
-            System.Diagnostics.Debug.WriteLine("Requesting permissions");
         }
 
         public void OnComplete(Task task)


### PR DESCRIPTION
Previous code was found to crash on Oreo devices.  It is better to have the actual app check and request permissions so that localization can be better handled.