### PR TITLE
issue #24 fix for OnConnected also issue #23 for accessing Regions

### DIFF
--- a/src/Plugin.Geofence/GeofenceImplementation.android.cs
+++ b/src/Plugin.Geofence/GeofenceImplementation.android.cs
@@ -125,7 +125,7 @@ namespace Plugin.Geofence
                     CurrentRequestType = RequestType.Default;
                     if(IsMonitoring)
                     {
-                        StartMonitoring(Regions.Values.ToList());
+                        StartMonitoringFrom(Regions);
                         System.Diagnostics.Debug.WriteLine(string.Format("{0} - {1}", CrossGeofence.Id, "Monitoring was restored"));
                     }
                 }
@@ -221,6 +221,16 @@ namespace Plugin.Geofence
                 }
                 //Request to add geofence regions once connected
                 CurrentRequestType = RequestType.Add;
+            }
+        }
+
+        private void StartMonitoringFrom(IReadOnlyDictionary<string, GeofenceCircularRegion> regionsDictionary)
+        {
+            // there is only one lock, which is re-entrant, it's fine to call
+            // another method which locks on the same lock here
+            lock (Lock)
+            {
+                StartMonitoring(regionsDictionary.Values.ToList());
             }
         }
 

--- a/src/Plugin.Geofence/GeofenceImplementation.android.cs
+++ b/src/Plugin.Geofence/GeofenceImplementation.android.cs
@@ -140,44 +140,48 @@ namespace Plugin.Geofence
 
         public void IsLocationEnabled(Action<bool> returnAction)
         {
-            InitializeGoogleAPI();
-            if(mGoogleApiClient == null || CheckPermissions() == false)
+            lock (Lock)
             {
-                returnAction(false);
-                return;
-            }
-            mFusedLocationProviderClient = LocationServices.GetFusedLocationProviderClient(Android.App.Application.Context);
-            mGeofencingClient = LocationServices.GetGeofencingClient(Application.Context);
-            mGeofenceList = new List<Android.Gms.Location.IGeofence>();
-
-            var locationRequestPriority = LocationRequest.PriorityBalancedPowerAccuracy;
-            switch (CrossGeofence.GeofencePriority)
-            {
-                case GeofencePriority.HighAccuracy:
-                    locationRequestPriority = LocationRequest.PriorityHighAccuracy;
-                    break;
-                case GeofencePriority.LowAccuracy:
-                    locationRequestPriority = LocationRequest.PriorityLowPower;
-                    break;
-                case GeofencePriority.LowestAccuracy:
-                    locationRequestPriority = LocationRequest.PriorityNoPower;
-                    break;
-            }
-            
-            mLocationRequest = new LocationRequest();
-            mLocationRequest.SetPriority(locationRequestPriority);
-            mLocationRequest.SetInterval(CrossGeofence.LocationUpdatesInterval);
-            mLocationRequest.SetFastestInterval(CrossGeofence.FastestLocationUpdatesInterval);
-
-            LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder().AddLocationRequest(mLocationRequest);
-            var pendingResult = LocationServices.SettingsApi.CheckLocationSettings(mGoogleApiClient, builder.Build());
-            pendingResult.SetResultCallback((LocationSettingsResult locationSettingsResult) => {
-                if (locationSettingsResult != null)
+                InitializeGoogleAPI();
+                if (mGoogleApiClient == null || CheckPermissions() == false)
                 {
-                    returnAction(locationSettingsResult.Status.StatusCode <= CommonStatusCodes.Success);
-                } 
-            });
-            System.Diagnostics.Debug.WriteLine("End of IsLocationEnabled, clients should be created");
+                    returnAction(false);
+                    return;
+                }
+                mFusedLocationProviderClient = LocationServices.GetFusedLocationProviderClient(Android.App.Application.Context);
+                mGeofencingClient = LocationServices.GetGeofencingClient(Application.Context);
+                mGeofenceList = new List<Android.Gms.Location.IGeofence>();
+
+                var locationRequestPriority = LocationRequest.PriorityBalancedPowerAccuracy;
+                switch (CrossGeofence.GeofencePriority)
+                {
+                    case GeofencePriority.HighAccuracy:
+                        locationRequestPriority = LocationRequest.PriorityHighAccuracy;
+                        break;
+                    case GeofencePriority.LowAccuracy:
+                        locationRequestPriority = LocationRequest.PriorityLowPower;
+                        break;
+                    case GeofencePriority.LowestAccuracy:
+                        locationRequestPriority = LocationRequest.PriorityNoPower;
+                        break;
+                }
+
+                mLocationRequest = new LocationRequest();
+                mLocationRequest.SetPriority(locationRequestPriority);
+                mLocationRequest.SetInterval(CrossGeofence.LocationUpdatesInterval);
+                mLocationRequest.SetFastestInterval(CrossGeofence.FastestLocationUpdatesInterval);
+
+                LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder().AddLocationRequest(mLocationRequest);
+                var pendingResult = LocationServices.SettingsApi.CheckLocationSettings(mGoogleApiClient, builder.Build());
+                pendingResult.SetResultCallback((LocationSettingsResult locationSettingsResult) =>
+                {
+                    if (locationSettingsResult != null)
+                    {
+                        returnAction(locationSettingsResult.Status.StatusCode <= CommonStatusCodes.Success);
+                    }
+                });
+                System.Diagnostics.Debug.WriteLine("End of IsLocationEnabled, clients should be created");
+            }
         }
 
         /// <summary>
@@ -521,7 +525,15 @@ namespace Plugin.Geofence
  
         async public void OnConnected(Bundle connectionHint)
         {
-            var location = await mFusedLocationProviderClient.GetLastLocationAsync();
+            FusedLocationProviderClient localClient = null;
+            // must lock here to ensure initialization is complete before this callback is executed by another thread.
+            // accessing the member var `mFusedLocationProviderClient` within the lock ensures variable publishing.
+            // the local scoped variable can reference the member instance then `await` syntax used outside the lock. 
+            lock (Lock)
+            {
+                localClient = mFusedLocationProviderClient;
+            }
+            var location = await localClient.GetLastLocationAsync();
             SetLastKnownLocation(location);
             if (CurrentRequestType == RequestType.Add)
             {


### PR DESCRIPTION
This is a fix for the crash caused by issue #24, a null pointer, with the top of the stack trace at GeofenceImplementation.OnConnected.  The issue is that the callback is registered by the InitializeGoogleAPI method which is called by the constructor.  But, the callback may then be executed by another thread, before the thread executing the constructor has fully completed and initialized all variables (or that constructor thread may be done but the variables are not published to all threads). 

The fix is to guard the initialization logic with the same lock used to guard other variables in the class. This will ensure the constructor will finish, before the callback directly accesses any of the member variables initialized by the constructor logic. 
 
This also addresses the crash from issue #23, which is a crash caused when the Regions dictionary is modified by a thread while another thread is iterating. The top of the stack trace is "Dictionary.ValueCollection[TKey,TValue].CopyTo".  The root cause is that a list is passed to "StartMonitoring(Regions.Values.ToList())" but the underlying Dictionary can be modified while the list is being created.  The resulting List is guarded by a lock, but it's too late. The whole Regions Dictionary should be guarded by the lock each time it is accessed.

