### PR TITLE
Update GeofenceBootReceiver for Android 12 support

### DIFF
--- a/src/Plugin.Geofence/GeofenceBootReceiver.android.cs
+++ b/src/Plugin.Geofence/GeofenceBootReceiver.android.cs
@@ -7,7 +7,7 @@ namespace Plugin.Geofence
     /// GeofenceBootReceiver class
     /// Receives BOOT_COMPLETED event
     /// </summary>
-    [BroadcastReceiver]
+    [BroadcastReceiver(Enabled = true, Exported = false)]
     [IntentFilter(new[] { Intent.ActionBootCompleted})]
     public class GeofenceBootReceiver : BroadcastReceiver
     {


### PR DESCRIPTION
For Android 12 it is now mandatory to explicit supply a value for android:exported for intent filters.